### PR TITLE
Add XUnit headless tests as a sample

### DIFF
--- a/AvaloniaXpfSamples.sln
+++ b/AvaloniaXpfSamples.sln
@@ -22,6 +22,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XpfDotNetBrowserApp", "src\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PdfPreviewSample", "src\PdfPreviewSample\PdfPreviewSample.csproj", "{AA584A56-6734-4C43-AACE-DF1224797CD2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7A7A7296-9807-462E-B6E4-CC16D7F9EFD5}"
+	ProjectSection(SolutionItems) = preProject
+		NuGet.config = NuGet.config
+		readme.md = readme.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfCalculator.Tests", "tests\WpfCalculator.Tests\WpfCalculator.Tests.csproj", "{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -152,6 +160,18 @@ Global
 		{AA584A56-6734-4C43-AACE-DF1224797CD2}.Release|x64.Build.0 = Release|Any CPU
 		{AA584A56-6734-4C43-AACE-DF1224797CD2}.Release|x86.ActiveCfg = Release|Any CPU
 		{AA584A56-6734-4C43-AACE-DF1224797CD2}.Release|x86.Build.0 = Release|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Debug|x64.Build.0 = Debug|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Debug|x86.Build.0 = Debug|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Release|x64.ActiveCfg = Release|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Release|x64.Build.0 = Release|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Release|x86.ActiveCfg = Release|Any CPU
+		{E4B26BC0-83B3-4ED1-9200-2F3E6E98B093}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ This sample demonstrates how you can add WPF controls to your existing Avalonia 
 
 ## Mobile & WebAssembly 
 We have iOS, Android and WebAssembly support in preview with select customers. To enable these platforms, we recommend creating a Single Project, which contains Desktop, Mobile and Web versions of your WPF applications. 
-The sample app demonstrates this apporach. 
+The sample app demonstrates this approach. 
 
 ![WASM Screenshot](/assets/wasm-calc.png)
 

--- a/src/WpfCalculator/MainWindow.cs
+++ b/src/WpfCalculator/MainWindow.cs
@@ -143,6 +143,37 @@ namespace WpfCalculator
             _result = 0;
             labelResult.Content = $"{_lastNumber}";
         }
+
+        private void MainWindow_OnTextInput(object sender, TextCompositionEventArgs e)
+        {
+            var s = e.Text;
+            var c = (s.ToCharArray())[0];
+            e.Handled = true;
+
+            if ((c >= '0' && c <= '9') || c == '.' || c == '\b') // '\b' is backspace
+            {
+                _setNumber(c - '0');
+                return;
+            }
+            switch (c)
+            {
+                case '+':
+                    _buttonOperation_Click(buttonAdd, e);
+                    break;
+                case '-':
+                    _buttonOperation_Click(buttonSubtract, e);
+                    break;
+                case '*':
+                    _buttonOperation_Click(buttonMultiply, e);
+                    break;
+                case '/':
+                    _buttonOperation_Click(buttonDivide, e);
+                    break;
+                case '=':
+                    _buttonEqual_Click(buttonEqual, e);
+                    break;
+            }
+        }
     }
 
     public enum Operator

--- a/src/WpfCalculator/MainWindow.xaml
+++ b/src/WpfCalculator/MainWindow.xaml
@@ -5,7 +5,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:WpfCalculator"
         mc:Ignorable="d"
-        Title="Calculator" d:Height="500" d:Width="300" Background="#111" Icon="appicon.ico">
+        Title="Calculator" d:Height="500" d:Width="300" Background="#111" Icon="appicon.ico"
+        TextInput="MainWindow_OnTextInput">
     <Grid Margin="10">
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -23,6 +24,7 @@
         </Grid.RowDefinitions>
 
         <Label x:Name="labelResult" 
+               x:FieldModifier="public"
                Content="0"
                Style="{StaticResource resultLabelStyle}"
                HorizontalAlignment="Right"
@@ -31,21 +33,25 @@
         
         <!-- ROW 1 -->
         <Button x:Name="buttonAllClear"
+                x:FieldModifier="public"
                 Content="C"
                 Style="{StaticResource additionalButtonsStyle}"
                 Grid.Row="1"
                 Grid.Column="0"/>
         <Button x:Name="buttonNegative"
+                x:FieldModifier="public"
                 Content="-/+"
                 Style="{StaticResource additionalButtonsStyle}"
                 Grid.Row="1"
                 Grid.Column="1"/>
         <Button x:Name="buttonPercent"
+                x:FieldModifier="public"
                 Content="%"
                 Style="{StaticResource additionalButtonsStyle}"
                 Grid.Row="1"
                 Grid.Column="2"/>
         <Button x:Name="buttonDivide"
+                x:FieldModifier="public"
                 Click="_buttonOperation_Click"
                 Content="÷"
                 Style="{StaticResource operatorButtonStyle}"
@@ -54,21 +60,25 @@
 
         <!-- ROW 2 -->
         <Button x:Name="button7"
+                x:FieldModifier="public"
                 Content="7"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="2"
                 Grid.Column="0"/>
         <Button x:Name="button8"
+                x:FieldModifier="public"
                 Content="8"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="2"
                 Grid.Column="1"/>
         <Button x:Name="button9"
+                x:FieldModifier="public"
                 Content="9"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="2"
                 Grid.Column="2"/>
         <Button x:Name="buttonMultiply"
+                x:FieldModifier="public"
                 Click="_buttonOperation_Click"
                 Content="×"
                 Style="{StaticResource operatorButtonStyle}"
@@ -77,21 +87,25 @@
 
         <!-- ROW 3 -->
         <Button x:Name="button4"
+                x:FieldModifier="public"
                 Content="4"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="3"
                 Grid.Column="0"/>
         <Button x:Name="button5"
+                x:FieldModifier="public"
                 Content="5"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="3"
                 Grid.Column="1"/>
         <Button x:Name="button6"
+                x:FieldModifier="public"
                 Content="6"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="3"
                 Grid.Column="2"/>
         <Button x:Name="buttonSubtract"
+                x:FieldModifier="public"
                 Click="_buttonOperation_Click"
                 Content="-"
                 Style="{StaticResource operatorButtonStyle}"
@@ -100,21 +114,25 @@
         
         <!-- ROW 4 -->
         <Button x:Name="button1"
+                x:FieldModifier="public"
                 Content="1"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="4"
                 Grid.Column="0"/>
         <Button x:Name="button2"
+                x:FieldModifier="public"
                 Content="2"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="4"
                 Grid.Column="1"/>
         <Button x:Name="button3"
+                x:FieldModifier="public"
                 Content="3"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="4"
                 Grid.Column="2"/>
         <Button x:Name="buttonAdd"
+                x:FieldModifier="public"
                 Click="_buttonOperation_Click"
                 Content="+"
                 Style="{StaticResource operatorButtonStyle}"
@@ -123,17 +141,20 @@
 
         <!-- ROW 5 -->
         <Button x:Name="button0"
+                x:FieldModifier="public"
                 Content="0"
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="5"
                 Grid.Column="0"
                 Grid.ColumnSpan="2"/>
         <Button x:Name="buttonDecimal"
+                x:FieldModifier="public"
                 Content="."
                 Style="{StaticResource numberButtonStyle}"
                 Grid.Row="5"
                 Grid.Column="2"/>
         <Button x:Name="buttonEqual"
+                x:FieldModifier="public"
                 Content="="
                 Style="{StaticResource operatorButtonStyle}"
                 Grid.Row="5"

--- a/src/WpfCalculator/WpfCalculator.csproj
+++ b/src/WpfCalculator/WpfCalculator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Xpf.Sdk/1.4.0-cibuild001849">
+<Project Sdk="Xpf.Sdk/1.5.3">
     <PropertyGroup>
         <TargetFrameworks>net8.0;net8.0-ios;net8.0-android;net8.0-browser</TargetFrameworks>
         <UseWpf>true</UseWpf>

--- a/tests/WpfCalculator.Tests/OperationTests.cs
+++ b/tests/WpfCalculator.Tests/OperationTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Rendering.Composition;
+using AvaloniaUI.Xpf.WpfAbstractions;
+using AvDispatcher = Avalonia.Threading.Dispatcher;
+
+namespace WpfCalculator.Tests;
+
+public class OperationTests : IDisposable
+{
+    [AvaloniaFact]
+    public void Should_Raise_Click_Events()
+    {
+        // We use Application.MainWindow, because Application.StartupUri was set.
+        // If not set, we would need to create and show the MainWindow manually here.
+        // Note, as it is now, MainWindow is shared between tests, so tests must reset its state if needed.
+        // See Dispose() method below.
+
+        var mainWindow = (MainWindow)Application.Current.MainWindow!;
+        mainWindow.button2.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+        mainWindow.button1.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+
+        mainWindow.buttonMultiply.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+
+        mainWindow.button2.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+
+        mainWindow.buttonEqual.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+
+        Assert.Equal("42", mainWindow.labelResult.Content);
+    }
+
+    [AvaloniaFact]
+    public void Should_Use_Avalonia_Headless_Extensions()
+    {
+        var wpfWindow = (MainWindow)Application.Current.MainWindow!;
+        var avWindow = XpfWpfAbstraction.GetAvaloniaWindowForWindow(wpfWindow);
+        Assert.NotNull(avWindow);
+
+        // It's still possible to raise fake TextInput WPF events directly,
+        // But sometimes it's just easier to use helper methods.
+        avWindow.KeyTextInput("2");
+        avWindow.KeyTextInput("1");
+
+        avWindow.KeyTextInput("*");
+
+        avWindow.KeyTextInput("2");
+
+        avWindow.KeyTextInput("=");
+
+        Assert.Equal("42", wpfWindow.labelResult.Content);
+    }
+
+    [AvaloniaFact]
+    public void Should_Capture_Latest_Frame()
+    {
+        var wpfWindow = (MainWindow)Application.Current.MainWindow!;
+        var avWindow = XpfWpfAbstraction.GetAvaloniaWindowForWindow(wpfWindow);
+        Assert.NotNull(avWindow);
+
+        using var frame = avWindow.CaptureRenderedFrame();
+        Assert.NotNull(frame);
+
+        // After frame captured, it can be saved to the file or compared in-memory with expected frame.
+        // In this test we just want to know that frame is not empty.
+
+        using var memoryStream = new MemoryStream();
+        frame.Save(memoryStream);
+
+        Assert.True(memoryStream.Length > 0);
+    }
+
+    public void Dispose()
+    {
+        // Reset calculator state between tests.
+        // Alternatively, we could create a new MainWindow instance for each test, and remove StartupUri from App.xaml.
+        var wpfWindow = (MainWindow)Application.Current.MainWindow!;
+        wpfWindow.buttonAllClear.RaiseEvent(new RoutedEventArgs(ButtonBase.ClickEvent));
+    }
+}

--- a/tests/WpfCalculator.Tests/TestAppBuilder.cs
+++ b/tests/WpfCalculator.Tests/TestAppBuilder.cs
@@ -1,0 +1,50 @@
+using System.Threading;
+using System.Windows.Threading;
+using Avalonia;
+using Avalonia.Headless;
+using AvaloniaUI.Xpf;
+using AvaloniaUI.Xpf.Helpers;
+using WpfCalculator.Tests;
+
+// Specify the Avalonia test application builder for this test assembly. It will be executed once.
+[assembly: AvaloniaTestApplication(typeof(TestAppBuilder))]
+
+// Unlike Avalonia, we want to share the same WPF Application between all tests in the assembly.
+// This is needed before WPF is not designed to have multiple Application instances in the same AppDomain.
+[assembly: AvaloniaTestIsolation(AvaloniaTestIsolationLevel.PerAssembly)]
+
+// Disable parallelization of tests in this assembly, because WPF Application is shared.
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
+
+namespace WpfCalculator.Tests;
+
+public class TestAppBuilder
+{
+    // See https://docs.avaloniaui.net/docs/concepts/headless/headless-xunit
+    // XPF specific: https://docs.avaloniaui.net/xpf/advanced/headless-testing
+    public static AppBuilder BuildAvaloniaApp() => AppBuilder.Configure<DefaultXpfAvaloniaApplication>()
+        .WithAvaloniaXpf()
+        .UseSkia()
+        .UseHeadless(new AvaloniaHeadlessPlatformOptions
+        {
+            // See https://docs.avaloniaui.net/docs/concepts/headless/#capturing-the-last-rendered-frame
+            // We need that for frame capturing 
+            UseHeadlessDrawing = false
+        })
+        .AfterSetup(_ =>
+        {
+            // Setup WPF application.
+            var app = new App();
+            app.InitializeComponent();
+
+            // Force Application initialization callbacks early.
+            // This is needed to ensure that Application is fully initialized before tests run.
+            var frame = new DispatcherFrame();
+            Dispatcher.CurrentDispatcher.InvokeAsync(() => frame.Continue = false);
+            Dispatcher.PushFrame(frame);
+            
+            // Set WPF DispatcherSynchronizationContext as current SynchronizationContext.
+            // By default, Avalonia sets AvaloniaSynchronizationContext.
+            SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
+        });
+}

--- a/tests/WpfCalculator.Tests/WpfCalculator.Tests.csproj
+++ b/tests/WpfCalculator.Tests/WpfCalculator.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Xpf.Sdk/1.5.3">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+        <!-- Important to disable automatic Avalonia XPF initialization, because tests will do it manually -->
+        <DisableAutomaticXpfInit>true</DisableAutomaticXpfInit>
+    </PropertyGroup>
+
+    <ItemGroup>
+<!--        <PackageReference Include="Avalonia.Headless.XUnit" Version="$(XpfAvaloniaVersion)" />-->
+        <PackageReference Include="Avalonia.Headless.XUnit" Version="11.3.999-cibuild0059922-alpha" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="xunit" Version="2.5.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <RuntimeHostConfigurationOption Include="AvaloniaUI.Xpf.LicenseKey" Value="$(XpfLicenseKey)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\WpfCalculator\WpfCalculator.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Mostly ported from the old internal samples' repository. With several adjustments and fixes.
WpfCalculator project was used for WpfCalculator.Tests headless tests.